### PR TITLE
Ensure tests don't require network

### DIFF
--- a/test_error_handling.py
+++ b/test_error_handling.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 import sqlite3
+from bs4 import BeautifulSoup
 import Statutes_at_5 as statutes
 
 class TestErrorHandling(unittest.TestCase):
@@ -10,7 +11,10 @@ class TestErrorHandling(unittest.TestCase):
             self.assertEqual(result, (None, None))
 
     def test_db_error_handling(self):
-        with patch('sqlite3.connect', side_effect=sqlite3.DatabaseError('DB error')):
+        html = '<table id="maintable"></table>'
+        fake_soup = BeautifulSoup(html, 'html.parser')
+        with patch('sqlite3.connect', side_effect=sqlite3.DatabaseError('DB error')), \
+             patch('Statutes_at_5.fetch_html', return_value=(fake_soup, html.encode())):
             with self.assertRaises(sqlite3.DatabaseError):
                 # Try to run main, which should raise the DB error
                 statutes.main()

--- a/test_resumability.py
+++ b/test_resumability.py
@@ -2,7 +2,37 @@ import os
 import sqlite3
 import pytest
 from unittest import mock
+from bs4 import BeautifulSoup
 from Statutes_at_5 import main
+
+
+def fake_fetch_html(url, *args, **kwargs):
+    """Return deterministic HTML content based on the requested URL."""
+    if "Mode=View%20Statutes" in url:
+        html = (
+            '<table id="maintable">'
+            '<a href="index.cfm?App_mode=Display_Index&Title_Request=TITLE I">'
+            'TITLE I</a></table>'
+        )
+    elif "App_mode=Display_Index" in url and "Title_Request=TITLE I" in url:
+        html = (
+            '<a href="index.cfm?App_mode=Display_Statute&URL=Chapter1/ContentsIndex.html&StatuteYear=2023">'
+            'Chapter 1</a>'
+        )
+    elif "ContentsIndex.html" in url:
+        html = (
+            '<a href="index.cfm?App_mode=Display_Statute&URL=Chapter1/Sections/0001.01.html">'
+            '1.01</a>'
+        )
+    elif "Sections/0001.01.html" in url:
+        html = (
+            '<h2>1.01 Statute Title</h2>'
+            '<table id="maintable"><p>(1) Statute text.</p></table>'
+        )
+    else:
+        return None, None
+    soup = BeautifulSoup(html, "html.parser")
+    return soup, html.encode()
 
 def test_resumability(tmp_path):
     db_file = tmp_path / "test_statutes.db"
@@ -14,8 +44,9 @@ rate_limit_seconds = 0
 user_agent = test-agent
 index_url = http://www.leg.state.fl.us/Statutes/index.cfm?Mode=View%20Statutes&Submenu=1&Tab=statutes
 """)
-    # Patch required_titles to only process one title for speed
-    with mock.patch("Statutes_at_5.required_titles", ["TITLE I"]):
+    # Patch required_titles and fetch_html so the test does not hit the network
+    with mock.patch("Statutes_at_5.required_titles", ["TITLE I"]), \
+         mock.patch("Statutes_at_5.fetch_html", side_effect=fake_fetch_html):
         main()
         # Simulate interruption: mark one statute as incomplete
         conn = sqlite3.connect(db_file)


### PR DESCRIPTION
## Summary
- mock `fetch_html` in `test_resumability` so the test uses predefined HTML
- patch `test_error_handling` to avoid hitting the network when checking DB errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6efdb8848328be9bbf77e739e623